### PR TITLE
Docker: Fix healthcheck script

### DIFF
--- a/docker/healthcheck.py
+++ b/docker/healthcheck.py
@@ -6,12 +6,13 @@ Script that runs inside the Docker container and ensures that it's healthy.
 import http.client
 import os
 
+HOST = '127.0.0.1'
 PORT = 8000
 
 if __name__ == '__main__':
     hostname = os.environ.get('ALLOWED_HOST', 'localhost')
-    conn = http.client.HTTPConnection(f'{hostname}:{PORT}')
-    conn.request('GET', '/healthcheck/')
+    conn = http.client.HTTPConnection(f'{HOST}:{PORT}')
+    conn.request('GET', '/healthcheck/', headers={'host': hostname})
     response = conn.getresponse()
     print(f'HTTP {response.status} {response.reason}')
     body = response.read().decode('utf8')


### PR DESCRIPTION
Always connect to localhost, but set the `host` header.